### PR TITLE
Add basic UI for generator with click to regenerate

### DIFF
--- a/app/src/main/java/com/example/palletify/data/GeneratorData.kt
+++ b/app/src/main/java/com/example/palletify/data/GeneratorData.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import kotlin.random.Random
 
 
 const val MAX_NO_OF_WORDS = 10
@@ -213,11 +214,13 @@ data class RandomColourResponseBody(
     val hsl: String,
 )
 
+private val modeOptions = listOf("monochrome", "monochrome-dark", "monochrome-light", "analogic", "complement", "analogic-complement", "triad", "quad")
+
 private val jsonBuilder = Json { ignoreUnknownKeys = true }
 
 fun fetchPalette(
     seed: String,
-    mode: String = "monochrome",
+    mode: String = modeOptions[Random.nextInt(modeOptions.size)],
     numOfColours: Int = 5
 ): PaletteResponseBody {
     val client = OkHttpClient()
@@ -260,9 +263,9 @@ data class Hex(
 @Serializable
 data class Rgb(
     val fraction: RgBFraction,
-    val r: Int,
-    val g: Int,
-    val b: Int,
+    val r: Float,
+    val g: Float,
+    val b: Float,
     val value: String,
 )
 

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -4,11 +4,13 @@ import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -20,7 +22,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MaterialTheme.shapes
 import androidx.compose.material3.MaterialTheme.typography
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -30,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -37,11 +39,11 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.palletify.R
 import com.example.palletify.ui.theme.PalletifyTheme
+import kotlin.concurrent.thread
 
 @Composable
 fun GeneratorScreen(gameViewModel: GeneratorViewModel = viewModel()) {
@@ -52,64 +54,101 @@ fun GeneratorScreen(gameViewModel: GeneratorViewModel = viewModel()) {
         modifier = Modifier
             .statusBarsPadding()
             .verticalScroll(rememberScrollState())
-            .safeDrawingPadding()
-            .padding(mediumPadding),
+            .safeDrawingPadding(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = typography.titleLarge,
-        )
-        GameLayout(
-            onUserGuessChanged = { gameViewModel.updateUserGuess(it) },
-            wordCount = gameUiState.currentWordCount,
-            userGuess = gameViewModel.userGuess,
-            onKeyboardDone = { gameViewModel.checkUserGuess() },
-            currentScrambledWord = gameUiState.currentScrambledWord,
-            isGuessWrong = gameUiState.isGuessedWordWrong,
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .padding(mediumPadding)
-        )
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(mediumPadding),
-            verticalArrangement = Arrangement.spacedBy(mediumPadding),
-            horizontalAlignment = Alignment.CenterHorizontally
+        Palette(colors = gameUiState.colors)
+        Button(
+            onClick = {
+                thread { gameViewModel.getRandomPalette() } }
         ) {
-
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { gameViewModel.checkUserGuess() }
-            ) {
-                Text(
-                    text = stringResource(R.string.submit),
-                    fontSize = 16.sp
-                )
-            }
-
-            OutlinedButton(
-                onClick = { gameViewModel.skipWord() },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = stringResource(R.string.skip),
-                    fontSize = 16.sp
-                )
-            }
+            Text(text = "Generate")
         }
 
-        GameStatus(score = gameUiState.score, modifier = Modifier.padding(20.dp))
+//        Text(
+//            text = stringResource(R.string.app_name),
+//            style = typography.titleLarge,
+//        )
+//        GameLayout(
+//            onUserGuessChanged = { gameViewModel.updateUserGuess(it) },
+//            wordCount = gameUiState.currentWordCount,
+//            userGuess = gameViewModel.userGuess,
+//            onKeyboardDone = { gameViewModel.checkUserGuess() },
+//            currentScrambledWord = gameUiState.currentScrambledWord,
+//            isGuessWrong = gameUiState.isGuessedWordWrong,
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .wrapContentHeight()
+//                .padding(mediumPadding)
+//        )
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .padding(mediumPadding),
+//            verticalArrangement = Arrangement.spacedBy(mediumPadding),
+//            horizontalAlignment = Alignment.CenterHorizontally
+//        ) {
+//
+//            Button(
+//                modifier = Modifier.fillMaxWidth(),
+//                onClick = { gameViewModel.checkUserGuess() }
+//            ) {
+//                Text(
+//                    text = stringResource(R.string.submit),
+//                    fontSize = 16.sp
+//                )
+//            }
+//
+//            OutlinedButton(
+//                onClick = { gameViewModel.skipWord() },
+//                modifier = Modifier.fillMaxWidth()
+//            ) {
+//                Text(
+//                    text = stringResource(R.string.skip),
+//                    fontSize = 16.sp
+//                )
+//            }
+//        }
+//
+//        GameStatus(score = gameUiState.score, modifier = Modifier.padding(20.dp))
+//
+//        if (gameUiState.isGameOver) {
+//            FinalScoreDialog(
+//                score = gameUiState.score,
+//                onPlayAgain = { gameViewModel.resetGame() }
+//            )
+//        }
+    }
+}
 
-        if (gameUiState.isGameOver) {
-            FinalScoreDialog(
-                score = gameUiState.score,
-                onPlayAgain = { gameViewModel.resetGame() }
-            )
+@Composable
+fun Palette(colors: List<com.example.palletify.data.Color>) {
+    Column ( Modifier.fillMaxSize()){
+        colors.forEach {color ->
+            ColorInPalette(color)
         }
+    }
+}
+
+@Composable
+fun ColorInPalette(color: com.example.palletify.data.Color) {
+    val backgroundColor = Color(color.rgb.fraction.r, color.rgb.fraction.g, color.rgb.fraction.b)
+    // formula from: https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
+    val luminosity2 = color.rgb.r * 0.299 + color.rgb.g * 0.587 + color.rgb.b * 0.114 // this is not compliant with W3C, need to modify it in another iteration
+    Row(
+        Modifier
+            .fillMaxSize()
+            .background(backgroundColor)
+            .padding(16.dp)) {
+        Column(
+            Modifier
+                .fillMaxHeight()
+                .padding(top = 16.dp, bottom = 16.dp)) {
+            Text(modifier = Modifier.padding(bottom=4.dp), text = color.hex.clean, color = if (luminosity2 >= 186) Color.Black else Color.White, style = typography.bodyLarge)
+            Text(text = color.name.value, color = if (luminosity2 >= 186) Color.Black else Color.White, style = typography.labelMedium)
+        }
+
     }
 }
 

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.example.palletify.data.MAX_NO_OF_WORDS
-import com.example.palletify.data.PaletteResponseBody
 import com.example.palletify.data.SCORE_INCREASE
 import com.example.palletify.data.allWords
 import com.example.palletify.data.fetchPalette
@@ -47,29 +46,29 @@ class GeneratorViewModel : ViewModel() {
     */
     fun resetPalette() {
         usedColors.clear();
-
-        val palette = getRandomPalette();
-        _uiState.update { currentState ->
-            currentState.copy(
-                numberOfColours = palette.count,
-                colors = palette.colors,
-                mode = palette.mode,
-                image = palette.image
-            )
-        }
+        getRandomPalette();
 
     }
 
     /*
     * Generates a random palette based off a random color
     */
-    fun getRandomPalette(): PaletteResponseBody {
+    fun getRandomPalette() {
         val randomHexResponse = fetchRandomHex();
         return if (usedColors.contains(randomHexResponse)) {
             getRandomPalette();
         } else {
             usedColors.add(randomHexResponse);
-            fetchPalette(randomHexResponse);
+            val palette = fetchPalette(randomHexResponse);
+            _uiState.update { currentState ->
+                currentState.copy(
+                    numberOfColours = palette.count,
+                    colors = palette.colors,
+                    mode = palette.mode,
+                    image = palette.image
+                )
+            }
+
         }
     }
 

--- a/timelog.md
+++ b/timelog.md
@@ -3,4 +3,5 @@
 |02/17/2024  |        |          |0.5      |              |         |        |Set up initial project                         |
 |02/21/2024  |        |          |2        |              |         |        |Added template functions for generator         |
 |02/21/2024  |        |          |3        |              |         |        |Get random colour and palette from API         |
+|02/22/2024  |        |          |3.5      |              |         |        |Display and generate colour palette on click   |
 


### PR DESCRIPTION
This PR adds the functionality to see the generated palette in the UI, as well as regenerate a new palette with the click of the button.

https://github.com/emilyslouie/ece452-project/assets/52092223/09357015-ca2d-4af6-8591-5e0536cb1023

Todos:
- Fix the UI of the palette to be the entire available height of the screen
- Move the generate button to a bottom bar
- Fix the text displayed on the colour to be W3C compliant
- Identify and fix source of lag
