### PR TITLE
Implement undo/redo and add to timelog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,10 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
     compileOptions {
@@ -56,6 +59,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
 
     // for loading images
     implementation("io.coil-kt:coil-compose:2.5.0")

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Redo
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -54,18 +57,32 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                         .fillMaxWidth()
                         .padding(top = 16.dp, bottom = 16.dp),
                     horizontalArrangement = Arrangement.SpaceEvenly,
+                    // TODO: ensure that when the "more options button" is placed, that the generate button is in the middle
                 ) {
+                    Row() {
+                        IconButton(
+                            onClick = { generatorViewModel.handleUndo() },
+                            enabled = generatorUiState.palettesInUndoStack > 0
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = "Undo");
+                        }
+                        IconButton(
+                            onClick = { generatorViewModel.handleRedo() },
+                            enabled = generatorUiState.palettesInRedoStack > 0
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.Redo, contentDescription = "Redo");
+                        }
+                    }
                     Button(onClick = {
-                        thread { generatorViewModel.getRandomPalette() }
+                        thread { generatorViewModel.getNewRandomPalette() }
                     }) {
                         Text(
                             modifier = Modifier.padding(end = 4.dp),
                             text = stringResource(R.string.generate),
                             style = typography.titleLarge
                         )
-                        Icon(Icons.Filled.Refresh, contentDescription = "Localized description")
+                        Icon(Icons.Filled.Refresh, contentDescription = "Regenerate")
                     }
-
                 }
             }
         }
@@ -84,19 +101,19 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Palette(
-                colors = generatorUiState.colors,
+                colors = generatorUiState.currentPalette,
                 numOfColors = generatorUiState.numberOfColours,
                 heightAvailable = columnHeightDp
             )
         }
     }
-
 }
 
 
 @Composable
 fun Palette(colors: List<com.example.palletify.data.Color>, numOfColors: Int, heightAvailable: Dp) {
     val heightPerColor = heightAvailable / numOfColors;
+    // TODO: probably need to change this to be based on the number of colours so that we can add/subtract num of colours in a palette
     colors.forEach { color ->
         ColorInPalette(color, heightPerColor)
     }
@@ -146,7 +163,6 @@ fun ColorInPalette(color: com.example.palletify.data.Color, heightPerColor: Dp) 
                 style = typography.labelMedium
             )
         }
-
     }
 }
 

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorUiState.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorUiState.kt
@@ -8,8 +8,11 @@ import com.example.palletify.data.Image
  */
 data class GeneratorUiState(
     val numberOfColours: Int = 5,
-    val colors: List<Color> = emptyList(),
+    val currentPalette: List<Color> = emptyList(),
     val mode: String = "monochrome",
     val image: Image = Image("", ""),
-    val lockedColors: List<Color> = emptyList()
+    val lockedColors: List<Color> = emptyList(),
+    // Maintain a count for palettes in each undo/redo stack since the UI doesn't need the entire stack
+    var palettesInUndoStack: Int = 0,
+    var palettesInRedoStack: Int = 0,
 )

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -1,6 +1,8 @@
 package com.example.palletify.ui.generator
 
 import androidx.lifecycle.ViewModel
+import com.example.palletify.data.Color
+import com.example.palletify.data.Image
 import com.example.palletify.data.fetchPalette
 import com.example.palletify.data.fetchRandomHex
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,9 +20,22 @@ class GeneratorViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(GeneratorUiState())
     val uiState: StateFlow<GeneratorUiState> = _uiState.asStateFlow()
 
+    data class PaletteObj(
+        val numberOfColours: Int,
+        val colors: List<Color>,
+        val mode: String,
+        val image: Image,
+    )
 
     // Set of colors that have already been used as a seed in the generator
     private var usedSeedColors: MutableSet<String> = mutableSetOf()
+
+    // Current palette
+    private var currentPalette: PaletteObj = PaletteObj(0, emptyList(), "", Image("", ""));
+
+    // Stacks to keep palettes that can be undone and redone
+    private var undoPalettes: ArrayDeque<PaletteObj> = ArrayDeque();
+    private var redoPalettes: ArrayDeque<PaletteObj> = ArrayDeque();
 
     init {
         thread {
@@ -31,31 +46,101 @@ class GeneratorViewModel : ViewModel() {
     /*
     * Re-initializes the palette when first loading the generator
     */
-    fun resetPalette() {
+    private fun resetPalette() {
         usedSeedColors.clear();
-        getRandomPalette();
-
+        undoPalettes.clear();
+        redoPalettes.clear();
+        getNewRandomPalette();
     }
 
     /*
     * Generates a random palette based off a random color
     */
-    fun getRandomPalette() {
-        val randomHexResponse = fetchRandomHex();
-        return if (usedSeedColors.contains(randomHexResponse)) {
-            getRandomPalette();
-        } else {
-            usedSeedColors.add(randomHexResponse);
-            val palette = fetchPalette(randomHexResponse);
-            _uiState.update { currentState ->
-                currentState.copy(
-                    numberOfColours = palette.count,
-                    colors = palette.colors,
-                    mode = palette.mode,
-                    image = palette.image
-                )
-            }
+    private fun getRandomPalette(): PaletteObj {
+        val randomHexResponse = getRandomHex();
+        usedSeedColors.add(randomHexResponse);
+        val response = fetchPalette(randomHexResponse);
+        val newPalette = PaletteObj(response.count, response.colors, response.mode, response.image);
+        return newPalette;
+    }
 
+    /*
+    * Generates a random hex code
+    */
+    private fun getRandomHex(): String {
+        val response: String = fetchRandomHex();
+        return if (usedSeedColors.contains(response)) {
+            getRandomHex();
+        } else {
+            return response;
+        }
+    }
+
+    /*
+    * Updates the current palette in the ViewModel and UiState
+    */
+    private fun setCurrentPalette(palette: PaletteObj) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                numberOfColours = palette.numberOfColours,
+                currentPalette = palette.colors,
+                mode = palette.mode,
+                image = palette.image
+            )
+        }
+        currentPalette = palette;
+    }
+
+    /*
+    * Gets a random new palette, updates the current palette, and update undo/redo stacks
+    */
+    fun getNewRandomPalette() {
+        val palette = getRandomPalette();
+        var currentCountInUndoStack = _uiState.value.palettesInUndoStack;
+        if (currentPalette.numberOfColours > 0) {
+            undoPalettes.add(currentPalette);
+            currentCountInUndoStack++;
+        }
+        setCurrentPalette(palette);
+        // The redo stack is cleared if a new palette is generated
+        redoPalettes.clear();
+        _uiState.update { currentState ->
+            currentState.copy(
+                palettesInUndoStack = currentCountInUndoStack,
+                palettesInRedoStack = 0
+            );
+        }
+    }
+
+    /*
+    * Handle undo to go back to the previous palette
+    */
+    fun handleUndo() {
+        // This is the only time when palettes are added to the redo stack
+        redoPalettes.add(currentPalette);
+        val oldPalette = undoPalettes.removeLast();
+        setCurrentPalette(oldPalette);
+        _uiState.update { currentState ->
+            currentState.copy(
+                palettesInUndoStack = currentState.palettesInUndoStack - 1,
+                palettesInRedoStack = currentState.palettesInRedoStack + 1
+            );
+        }
+    }
+
+
+    /*
+    * Handle redo to go to a palette previous palette
+    */
+    fun handleRedo() {
+        undoPalettes.add(currentPalette);
+        val newPalette = redoPalettes.removeLast();
+        setCurrentPalette(newPalette);
+        _uiState.update { currentState ->
+            currentState.copy(
+                palettesInUndoStack = currentState.palettesInUndoStack + 1,
+                palettesInRedoStack = currentState.palettesInRedoStack - 1
+            );
         }
     }
 }

--- a/timelog.md
+++ b/timelog.md
@@ -5,4 +5,4 @@
 |02/21/2024  |        |          |3        |              |         |        |Get random colour and palette from API         |
 |02/22/2024  |        |          |3.5      |              |         |        |Display and generate colour palette on click   |
 |02/23/2024  |        |          |3        |              |         |        |Fix generator UI and text contrast             |
-
+|02/26/2024  |        |          |6        |              |         |        |Implement undo/redo for generating palettes    |


### PR DESCRIPTION

https://github.com/emilyslouie/ece452-project/assets/52092223/c029ef03-feeb-490e-bcef-e358f6618fc2

This PR implements stack data structures in the ViewModel to handle keeping palettes (PaletteObjs) for undo and redo actions. When adding to the stacks, the UI state is updated with the count of the number of palettes in the stacks. This is so that we don't need to pass the entire stack to the UI, although this makes for coupling such that whenever the stacks are updated, the UI's count for the stacks also need to be updated.

This PR also adds the Material Icons extended dependency so that we can get the icons for undo and redo as IconButtons in the UI.