### PR TITLE
Add and remove colours from palette

### DIFF
--- a/app/src/main/java/com/example/palletify/MainActivity.kt
+++ b/app/src/main/java/com/example/palletify/MainActivity.kt
@@ -1,45 +1,39 @@
 package com.example.palletify
 
-import com.example.palletify.ui.home.HomeScreen
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.example.palletify.ui.theme.PalletifyTheme
-import androidx.compose.material3.rememberDrawerState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import com.example.palletify.ui.generator.GeneratorScreen
-import com.example.palletify.ui.preview.PreviewScreen
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Menu
-import androidx.compose.material3.Divider
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.ui.unit.dp
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.palletify.ui.generator.GeneratorScreen
+import com.example.palletify.ui.home.HomeScreen
 import com.example.palletify.ui.library.Library
+import com.example.palletify.ui.preview.PreviewScreen
+import com.example.palletify.ui.theme.PalletifyTheme
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -50,7 +44,8 @@ class MainActivity : ComponentActivity() {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background)
+                    color = MaterialTheme.colorScheme.background
+                )
                 {
                     NavDrawer();
                 }
@@ -74,14 +69,7 @@ fun NavDrawer() {
         gesturesEnabled = true,
         drawerContent = {
             ModalDrawerSheet {
-                Box(modifier = Modifier
-                    .background(Color.Gray)
-                    .fillMaxWidth()
-                    .height(0.dp)) {
-                    Text(text="")
-                }
-                Divider()
-                NavigationDrawerItem(label = { Text(text="Home")},
+                NavigationDrawerItem(label = { Text(text = "Home") },
                     selected = false,
                     onClick = {
                         coroutineScope.launch {
@@ -91,7 +79,7 @@ fun NavDrawer() {
                             popUpTo(0)
                         }
                     })
-                NavigationDrawerItem(label = { Text(text="Library")},
+                NavigationDrawerItem(label = { Text(text = "Library") },
                     selected = false,
                     onClick = {
                         coroutineScope.launch {
@@ -101,7 +89,7 @@ fun NavDrawer() {
                             popUpTo(0)
                         }
                     })
-                NavigationDrawerItem(label = { Text(text="Preview")},
+                NavigationDrawerItem(label = { Text(text = "Preview") },
                     selected = false,
                     onClick = {
                         coroutineScope.launch {
@@ -117,10 +105,11 @@ fun NavDrawer() {
         Scaffold(
             topBar = {
                 val coroutineScope = rememberCoroutineScope()
-                TopAppBar(title = { Text(text = "Palletify") },
+                TopAppBar(
+                    title = { Text(text = "Palletify") },
                     colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = Color.Blue,
-                        titleContentColor = Color.White
+                        containerColor = Color.LightGray,
+                        titleContentColor = Color.Black
                     ),
                     navigationIcon = {
                         IconButton(onClick = {
@@ -136,8 +125,10 @@ fun NavDrawer() {
                 )
             }
         ) {
-            NavHost(navController = navigationController,
-                startDestination = Screens.Home.screen) {
+            NavHost(
+                navController = navigationController,
+                startDestination = Screens.Home.screen
+            ) {
                 composable(Screens.Home.screen) { HomeScreen(navigationController) }
                 composable(Screens.Library.screen) { Library() }
                 composable(Screens.PreviewScreen.screen) { PreviewScreen() }

--- a/app/src/main/java/com/example/palletify/data/GeneratorData.kt
+++ b/app/src/main/java/com/example/palletify/data/GeneratorData.kt
@@ -1,15 +1,13 @@
 package com.example.palletify.data
 
 
+import com.example.palletify.data.Palette.Color
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import kotlin.random.Random
-
-import com.example.palletify.data.Palette.Color;
-import com.example.palletify.data.Palette.Image;
 
 /**
  * Data that is needed for the generator
@@ -43,11 +41,15 @@ private val modeOptions = listOf(
     "quad"
 )
 
+fun getRandomGenerationMode(): String {
+    return modeOptions[Random.nextInt(modeOptions.size)];
+}
+
 private val jsonBuilder = Json { ignoreUnknownKeys = true }
 
 fun fetchPalette(
     seed: String,
-    mode: String = modeOptions[Random.nextInt(modeOptions.size)],
+    mode: String = getRandomGenerationMode(),
     numOfColours: Int = 5
 ): PaletteResponseBody {
     val client = OkHttpClient()
@@ -63,7 +65,6 @@ fun fetchPalette(
 data class PaletteResponseBody(
     val mode: String,
     val count: Int,
-    val colors: List<Color>,
-    val image: Image,
+    val colors: MutableList<Color>,
     val seed: Color,
 )

--- a/app/src/main/java/com/example/palletify/ui/components/BottomSheet.kt
+++ b/app/src/main/java/com/example/palletify/ui/components/BottomSheet.kt
@@ -1,0 +1,20 @@
+package com.example.palletify.ui.components
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BottomSheet(onDismiss: () -> Unit, content: @Composable() () -> Unit) {
+    val modalBottomSheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = { onDismiss() },
+        sheetState = modalBottomSheetState,
+        dragHandle = null,
+    ) {
+        content();
+    }
+}

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -60,12 +60,13 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
         mutableStateOf(0.dp)
     }
     val context = LocalContext.current
-    val palletViewModel1 = ViewModelProvider(context as ViewModelStoreOwner).get(PaletteViewModel::class.java)
+    val paletteViewModel =
+        ViewModelProvider(context as ViewModelStoreOwner)[PaletteViewModel::class.java]
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(top = 56.dp) // Adjust the value based on your design
+            .padding(top = 56.dp)
     ) {
         Scaffold(
             bottomBar = {
@@ -124,7 +125,7 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                                 generatorViewModel.uiState.value.currentPalette.component4().hex.value
                             val color5 =
                                 generatorViewModel.uiState.value.currentPalette.component5().hex.value
-                            val pallet = Palette(
+                            val palette = Palette(
                                 0,
                                 numberOfColors,
                                 color1 = color1,
@@ -135,7 +136,7 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                                 mode,
                                 favourite = false
                             )
-                            palletViewModel1.addPalette(pallet)
+                            paletteViewModel.addPalette(palette)
                         }
                         ) {
                             Text(

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -83,7 +83,7 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                             )
                             activeColor = null
                         }
-                    ), text = "Add color")
+                    ), text = "Add a new color to palette")
                 }
                 HorizontalDivider()
                 Row(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
@@ -95,7 +95,7 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                             )
                             activeColor = null
                         }
-                    ), text = "Remove color")
+                    ), text = "Remove this color from palette")
                 }
             }
 

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorUiState.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorUiState.kt
@@ -1,7 +1,6 @@
 package com.example.palletify.ui.generator
 
 import com.example.palletify.data.Palette.Color
-import com.example.palletify.data.Palette.Image
 
 /**
  * Data class that represents the generator's UI state
@@ -10,7 +9,6 @@ data class GeneratorUiState(
     val numberOfColours: Int = 5,
     val currentPalette: List<Color> = emptyList(),
     val mode: String = "monochrome",
-    val image: Image = Image("", ""),
     val lockedColors: MutableSet<Color> = mutableSetOf(),
     // Maintain a count for palettes in each undo/redo stack since the UI doesn't need the entire stack
     var palettesInUndoStack: Int = 0,

--- a/timelog.md
+++ b/timelog.md
@@ -18,3 +18,4 @@
 | 03/02/2024 |      |          |     |              |    1    |        | Refactor Model into separate files and fix conflicts             |
 | 03/02/2024 |      |          |     |      4       |         |        | Accessibility checker                                            |
 | 03/03/2024 |      |          |     |              |         |    1   | Add sample image color template                                  |
+| 03/12/2024 |      |          | 6   |              |         |        | Increase or decrease number of colours in palette                |


### PR DESCRIPTION
Clicking on the text in a colour of the palette opens up a bottom sheet. This allows you to add or remove a colour from the palette. 

For now, adding a colour will add the colour "white" right below the selected colour, and will be fixed once we implement our own colour generation methods. This is because I think when adding a new colour to the palette, we should generate it based on the colour that we initially clicked on to "Add a new colour".

The colour that is removed from the palette is the colour that was initially selected to bring up the bottom sheet.

The max number of colours that can be in a palette are 6, and the min is 3.

After adding a new colour or removing one, you can continue to generate palettes for the specified number of colours.

[Add or remove colours from palette.webm](https://github.com/emilyslouie/ece452-project/assets/52092223/78ae5ecb-7b0f-4763-9135-d9eaa849383b)


Some other minor things that were fixed in the PR:
- Changed the colour of the top bar and removing unnecessary code
- Created a "getRandomGenerationMode" method to be used in the ViewModel
- Fixed misc spelling mistakes

Todos for another PR:
- Fix UI to show a disabled state in the bottom sheet when you can no longer remove or add a new colour
- Make the UI in the bottom sheet look better
