### PR TITLE
Add list of trademarked colours and warn user if they are in the palette

### DIFF
--- a/app/src/main/java/com/example/palletify/data/TrademarkedColor.kt
+++ b/app/src/main/java/com/example/palletify/data/TrademarkedColor.kt
@@ -1,0 +1,296 @@
+package com.example.palletify.data
+
+class TrademarkedColor {
+    val hexes = setOf<String>(
+        "#0ABAB5",
+        "#3E3A34",
+        "#ED1C24",
+        "#FF6600",
+        "#367C2B",
+        "#6E3384",
+        "#3B5998",
+        "#CC0000",
+        "#FF2800",
+        "#E4007C",
+        "#0066CC",
+        "#0071C5",
+        "#FFC726",
+        "#660099",
+        "#FF6600",
+        "#FFD900",
+        "#00704A",
+        "#00A1F1",
+        "#4285F4",
+        "#FFC107",
+        "#A8A8A8",
+        "#1428A0",
+        "#1DA1F2",
+        "#0077B5",
+        "#005BBB",
+        "#FFD800",
+        "#006F44",
+        "#FF0000",
+        "#CC0000",
+        "#FFD700",
+        "#0D68B8",
+        "#FDB913",
+        "#DF2029",
+        "#003087",
+        "#007DC5",
+        "#00539B",
+        "#C8102E",
+        "#C60000",
+        "#FF0000",
+        "#221F1F",
+        "#00529F",
+        "#00549F",
+        "#005BBB",
+        "#BF0A30",
+        "#0033A0",
+        "#124191",
+        "#FBE000",
+        "#1ED760",
+        "#107C10",
+        "#003087",
+        "#FF0000",
+        "#1DA1F2",
+        "#0077B5",
+        "#CC0000",
+        "#FFD700",
+        "#0D68B8",
+        "#FDB913",
+        "#DF2029",
+        "#3E3A34",
+        "#660099",
+        "#FF6600",
+        "#00539B",
+        "#00704A",
+        "#C8102E",
+        "#C60000",
+        "#FF0000",
+        "#221F1F",
+        "#00529F",
+        "#ED1C24",
+        "#005BBB",
+        "#BF0A30",
+        "#0033A0",
+        "#124191",
+        "#FBE000",
+        "#1ED760",
+        "#107C10",
+        "#003087"
+    )
+    val colorsMap = mapOf<String, Palette.Color>(
+        "#0ABAB5" to Palette.Color(
+            Palette.Hex("#0ABAB5", "0ABAB5"),
+            Palette.Rgb(10, 186, 181),
+            Palette.Name("Tiffany Blue")
+        ),
+        "#3E3A34" to Palette.Color(
+            Palette.Hex("#3E3A34", "3E3A34"),
+            Palette.Rgb(62, 58, 52),
+            Palette.Name("Pullman Brown")
+        ),
+        "#ED1C24" to Palette.Color(
+            Palette.Hex("#ED1C24", "ED1C24"),
+            Palette.Rgb(237, 28, 36),
+            Palette.Name("Coca-Cola Red")
+        ),
+        "#FF6600" to Palette.Color(
+            Palette.Hex("#FF6600", "FF6600"),
+            Palette.Rgb(255, 102, 0),
+            Palette.Name("Orange")
+        ),
+        "#367C2B" to Palette.Color(
+            Palette.Hex("#367C2B", "367C2B"),
+            Palette.Rgb(54, 124, 43),
+            Palette.Name("John Deere Green")
+        ),
+        "#6E3384" to Palette.Color(
+            Palette.Hex("#6E3384", "6E3384"),
+            Palette.Rgb(110, 51, 132),
+            Palette.Name("Cadbury Purple")
+        ),
+        "#3B5998" to Palette.Color(
+            Palette.Hex("#3B5998", "3B5998"),
+            Palette.Rgb(59, 89, 152),
+            Palette.Name("Facebook Blue")
+        ),
+        "#CC0000" to Palette.Color(
+            Palette.Hex("#CC0000", "CC0000"),
+            Palette.Rgb(204, 0, 0),
+            Palette.Name("Target Red")
+        ),
+        "#FF2800" to Palette.Color(
+            Palette.Hex("#FF2800", "FF2800"),
+            Palette.Rgb(255, 40, 0),
+            Palette.Name("Ferrari Red")
+        ),
+        "#E4007C" to Palette.Color(
+            Palette.Hex("#E4007C", "E4007C"),
+            Palette.Rgb(228, 0, 124),
+            Palette.Name("Barbie Pink")
+        ),
+        "#0066CC" to Palette.Color(
+            Palette.Hex("#0066CC", "0066CC"),
+            Palette.Rgb(0, 102, 204),
+            Palette.Name("IBM Blue")
+        ),
+        "#0071C5" to Palette.Color(
+            Palette.Hex("#0071C5", "0071C5"),
+            Palette.Rgb(0, 113, 197),
+            Palette.Name("Intel Blue")
+        ),
+        "#FFC726" to Palette.Color(
+            Palette.Hex("#FFC726", "FFC726"),
+            Palette.Rgb(255, 199, 38),
+            Palette.Name("McDonald's Red")
+        ),
+        "#660099" to Palette.Color(
+            Palette.Hex("#660099", "660099"),
+            Palette.Rgb(102, 0, 153),
+            Palette.Name("FedEx Purple")
+        ),
+        "#FFD900" to Palette.Color(
+            Palette.Hex("#FFD900", "FFD900"),
+            Palette.Rgb(255, 217, 0),
+            Palette.Name("Shell Yellow")
+        ),
+        "#00704A" to Palette.Color(
+            Palette.Hex("#00704A", "00704A"),
+            Palette.Rgb(0, 112, 74),
+            Palette.Name("Starbucks Green")
+        ),
+        "#00A1F1" to Palette.Color(
+            Palette.Hex("#00A1F1", "00A1F1"),
+            Palette.Rgb(0, 161, 241),
+            Palette.Name("Microsoft Blue")
+        ),
+        "#4285F4" to Palette.Color(
+            Palette.Hex("#4285F4", "4285F4"),
+            Palette.Rgb(66, 133, 244),
+            Palette.Name("Google Blue")
+        ),
+        "#FFC107" to Palette.Color(
+            Palette.Hex("#FFC107", "FFC107"),
+            Palette.Rgb(255, 193, 7),
+            Palette.Name("Google Yellow")
+        ),
+        "#A8A8A8" to Palette.Color(
+            Palette.Hex("#A8A8A8", "A8A8A8"),
+            Palette.Rgb(168, 168, 168),
+            Palette.Name("Apple Silver")
+        ),
+        "#1428A0" to Palette.Color(
+            Palette.Hex("#1428A0", "1428A0"),
+            Palette.Rgb(20, 40, 160),
+            Palette.Name("Samsung Blue")
+        ),
+        "#1DA1F2" to Palette.Color(
+            Palette.Hex("#1DA1F2", "1DA1F2"),
+            Palette.Rgb(29, 161, 242),
+            Palette.Name("Twitter Blue")
+        ),
+        "#0077B5" to Palette.Color(
+            Palette.Hex("#0077B5", "0077B5"),
+            Palette.Rgb(0, 119, 181),
+            Palette.Name("LinkedIn Blue")
+        ),
+        "#005BBB" to Palette.Color(
+            Palette.Hex("#005BBB", "005BBB"),
+            Palette.Rgb(0, 91, 187),
+            Palette.Name("Pepsi Blue")
+        ),
+        "#BF0A30" to Palette.Color(
+            Palette.Hex("#BF0A30", "BF0A30"),
+            Palette.Rgb(191, 10, 48),
+            Palette.Name("KFC Red")
+        ),
+        "#0033A0" to Palette.Color(
+            Palette.Hex("#0033A0", "0033A0"),
+            Palette.Rgb(0, 51, 160),
+            Palette.Name("NASA Blue")
+        ),
+        "#124191" to Palette.Color(
+            Palette.Hex("#124191", "124191"),
+            Palette.Rgb(18, 65, 145),
+            Palette.Name("Nokia Blue")
+        ),
+        "#FBE000" to Palette.Color(
+            Palette.Hex("#FBE000", "FBE000"),
+            Palette.Rgb(251, 224, 0),
+            Palette.Name("Lego Yellow")
+        ),
+        "#1ED760" to Palette.Color(
+            Palette.Hex("#1ED760", "1ED760"),
+            Palette.Rgb(30, 215, 96),
+            Palette.Name("Spotify Green")
+        ),
+        "#107C10" to Palette.Color(
+            Palette.Hex("#107C10", "107C10"),
+            Palette.Rgb(16, 124, 16),
+            Palette.Name("Xbox Green")
+        ),
+        "#221F1F" to Palette.Color(
+            Palette.Hex("#221F1F", "221F1F"),
+            Palette.Rgb(34, 31, 31),
+            Palette.Name("Netflix Black")
+        ),
+        "#00529F" to Palette.Color(
+            Palette.Hex("#00529F", "00529F"),
+            Palette.Rgb(0, 82, 159),
+            Palette.Name("BMW Blue")
+        ),
+        "#C8102E" to Palette.Color(
+            Palette.Hex("#C8102E", "C8102E"),
+            Palette.Rgb(200, 16, 46),
+            Palette.Name("LG Red")
+        ),
+        "#FF0000" to Palette.Color(
+            Palette.Hex("#FF0000", "FF0000"),
+            Palette.Rgb(255, 0, 0),
+            Palette.Name("Adobe Red")
+        ),
+        "#007DC5" to Palette.Color(
+            Palette.Hex("#007DC5", "007DC5"),
+            Palette.Rgb(0, 125, 197),
+            Palette.Name("Walmart Blue")
+        ),
+        "#BF0A30" to Palette.Color(
+            Palette.Hex("#BF0A30", "BF0A30"),
+            Palette.Rgb(191, 10, 48),
+            Palette.Name("KFC Red")
+        ),
+        "#0033A0" to Palette.Color(
+            Palette.Hex("#0033A0", "0033A0"),
+            Palette.Rgb(0, 51, 160),
+            Palette.Name("NASA Blue")
+        ),
+        "#124191" to Palette.Color(
+            Palette.Hex("#124191", "124191"),
+            Palette.Rgb(18, 65, 145),
+            Palette.Name("Nokia Blue")
+        ),
+        "#FBE000" to Palette.Color(
+            Palette.Hex("#FBE000", "FBE000"),
+            Palette.Rgb(251, 224, 0),
+            Palette.Name("Lego Yellow")
+        ),
+        "#1ED760" to Palette.Color(
+            Palette.Hex("#1ED760", "1ED760"),
+            Palette.Rgb(30, 215, 96),
+            Palette.Name("Spotify Green")
+        ),
+        "#107C10" to Palette.Color(
+            Palette.Hex("#107C10", "107C10"),
+            Palette.Rgb(16, 124, 16),
+            Palette.Name("Xbox Green")
+        ),
+        "#221F1F" to Palette.Color(
+            Palette.Hex("#221F1F", "221F1F"),
+            Palette.Rgb(34, 31, 31),
+            Palette.Name("Netflix Black")
+        )
+
+    )
+}

--- a/app/src/main/java/com/example/palletify/ui/components/TrademarkComponentWrapper.kt
+++ b/app/src/main/java/com/example/palletify/ui/components/TrademarkComponentWrapper.kt
@@ -1,0 +1,61 @@
+package com.example.palletify.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.palletify.data.Palette
+
+@Composable
+fun TrademarkComponentWrapper(
+    color: Palette.Color,
+    list: Set<String>,
+    map: Map<String, Palette.Color>,
+    content: @Composable () -> Unit
+) {
+    val showDialog = remember { mutableStateOf(false) }
+
+    Box {
+        content()
+
+        if (list.contains(color.hex.value)) {
+            Icon(
+                Icons.Filled.Warning,
+                contentDescription = "Trademarked color",
+                tint = Color(0xFFFFA500),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(24.dp)
+                    .clickable { showDialog.value = true }
+            )
+        }
+
+        if (showDialog.value) {
+            val colorName = map[color.hex.value]?.name?.value;
+            AlertDialog(
+                onDismissRequest = { showDialog.value = false },
+                title = { Text("Trademarked Color Warning") },
+                text = { Text("This color is trademarked as $colorName and you should be careful about using it as the primary colour in your designs.") },
+                confirmButton = {
+                    TextButton(onClick = { showDialog.value = false }) {
+                        Text("OK")
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -56,6 +56,7 @@ import com.example.palletify.data.GenerationMode
 import com.example.palletify.database.Palette
 import com.example.palletify.database.PaletteViewModel
 import com.example.palletify.ui.components.BottomSheet
+import com.example.palletify.ui.components.TrademarkComponentWrapper
 import com.example.palletify.ui.theme.PalletifyTheme
 import kotlin.concurrent.thread
 import kotlin.math.pow
@@ -264,58 +265,64 @@ fun ColorInPalette(
     val generatorUiState by generatorViewModel.uiState.collectAsStateWithLifecycle()
     val luminosity =
         calculateLuminosity(color.rgb.r, color.rgb.g, color.rgb.b)
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(heightPerColor)
-            .background(hexToComposeColor(color.hex))
-            .padding(16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-
-        ) {
-        Column(
+    TrademarkComponentWrapper(
+        color = color,
+        list = generatorViewModel.trademarkedColor.hexes,
+        map = generatorViewModel.trademarkedColor.colorsMap
+    ) {
+        Row(
             modifier = Modifier
-                .padding(top = 16.dp, bottom = 16.dp)
-                .clickable { onItemClick(color) }
-        ) {
-            Text(
-                modifier = Modifier.padding(bottom = 4.dp),
-                text = color.hex.clean,
-                color = if (luminosity >= 0.179) Color.Black else Color.White,
-                style = typography.headlineSmall
-            )
-            Text(
-                text = color.name.value,
-                color = if (luminosity >= 0.179) Color(35, 35, 35) else Color(230, 230, 230),
-                style = typography.labelMedium
-            )
-        }
+                .fillMaxWidth()
+                .height(heightPerColor)
+                .background(hexToComposeColor(color.hex))
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
 
-        if (!generatorUiState.lockedColors.contains(color)) {
-            // Button to lock a colour
-            IconButton(
-                onClick = { generatorViewModel.handleLockForColor(color) }
             ) {
-                Icon(
-                    Icons.Filled.LockOpen,
-                    contentDescription = "Lock a colour",
-                    tint = if (luminosity >= 0.179) Color.Black else Color.White
+            Column(
+                modifier = Modifier
+                    .clickable { onItemClick(color) }
+            ) {
+                Text(
+                    modifier = Modifier.padding(bottom = 2.dp),
+                    text = color.hex.clean,
+                    color = if (luminosity >= 0.179) Color.Black else Color.White,
+                    style = typography.headlineSmall
+                )
+                Text(
+                    text = color.name.value,
+                    color = if (luminosity >= 0.179) Color(35, 35, 35) else Color(230, 230, 230),
+                    style = typography.labelMedium
                 )
             }
-        } else {
-            // Button to unlock a colour
-            IconButton(
-                onClick = { generatorViewModel.handleUnlockForColor(color) }
-            ) {
-                Icon(
-                    Icons.Filled.Lock,
-                    contentDescription = "Unlock a colour",
-                    tint = if (luminosity >= 0.179) Color.Black else Color.White
-                )
+
+            if (!generatorUiState.lockedColors.contains(color)) {
+                // Button to lock a colour
+                IconButton(
+                    onClick = { generatorViewModel.handleLockForColor(color) }
+                ) {
+                    Icon(
+                        Icons.Filled.LockOpen,
+                        contentDescription = "Lock a colour",
+                        tint = if (luminosity >= 0.179) Color.Black else Color.White
+                    )
+                }
+            } else {
+                // Button to unlock a colour
+                IconButton(
+                    onClick = { generatorViewModel.handleUnlockForColor(color) }
+                ) {
+                    Icon(
+                        Icons.Filled.Lock,
+                        contentDescription = "Unlock a colour",
+                        tint = if (luminosity >= 0.179) Color.Black else Color.White
+                    )
+                }
             }
         }
     }
+
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -3,6 +3,7 @@ package com.example.palletify.ui.generator
 import androidx.lifecycle.ViewModel
 import com.example.palletify.data.GenerationMode
 import com.example.palletify.data.Palette
+import com.example.palletify.data.TrademarkedColor
 import com.example.palletify.data.fetchPalette
 import com.example.palletify.data.fetchRandomColors
 import com.example.palletify.data.getRandomGenerationMode
@@ -44,6 +45,8 @@ class GeneratorViewModel : ViewModel() {
     // Stacks to keep palettes that can be undone and redone
     private var undoPalettes: ArrayDeque<PaletteObj> = ArrayDeque();
     private var redoPalettes: ArrayDeque<PaletteObj> = ArrayDeque();
+
+    val trademarkedColor = TrademarkedColor();
 
     init {
         thread {

--- a/timelog.md
+++ b/timelog.md
@@ -25,4 +25,5 @@
 | 03/26/2024 |      |          | 2     |             |        |      | Add random colour generator mode                                   |
 | 03/27/2024 |      |          | 2     |             |        |      | Fetch colour name and display it in generator                      |
 | 03/27/2024 | 5    |          |       |             |        |      | Add menu to choose generation mode, add monochrome generation mode |
-| 03/26/2024 |      |          | 8     |             |        |      | Add gradient colour generator mode                                 |
+| 03/28/2024 |      |          | 8     |             |        |      | Add gradient colour generator mode                                 |
+| 03/29/2024 |      |          | 8     |             |        |      | Create list of trademarked colours and warn user if used           |


### PR DESCRIPTION
This PR addresses the buddy team's feedback where if a colour has been trademarked. The list of 60 trademarked colours are stored in a class that is instantiated in the generator view model. This is passed a TrademarkComponentWrapper which is based on the AccessibleComponentWrapper which puts a warning icon on top of the colour if it has been trademarked. Clicking on the warning icon opens a dialog that tells the user what the name of the copyrighted colour is and to be careful about using it as the primary colour of their design. 

This PR also fixes some issue with the name not displaying if there are 6 colours in the palette. 

https://github.com/emilyslouie/ece452-project/assets/52092223/31ab8b25-ca14-44cb-a91c-d9c9e5d38f39


Ideally this would be an API that we create and ping but we will just put it in memory lol. 