### PR TITLE
Fix increase colors function to use our colour generation methods

### DIFF
--- a/app/src/main/java/com/example/palletify/data/GeneratorData.kt
+++ b/app/src/main/java/com/example/palletify/data/GeneratorData.kt
@@ -278,7 +278,11 @@ fun generateRandomPalette(
     count: Int
 ): MutableList<Palette.Color> {
     val result: MutableList<Palette.Color> = seeds.toMutableList();
-    result.addAll(fetchRandomColors(count - seeds.size));
+    val numOfColors = if (count == 1) 1 else count - seeds.size;
+    if (count == 1) {
+        result.clear();
+    }
+    result.addAll(fetchRandomColors(numOfColors));
     return result;
 }
 

--- a/app/src/main/java/com/example/palletify/data/GeneratorData.kt
+++ b/app/src/main/java/com/example/palletify/data/GeneratorData.kt
@@ -151,9 +151,15 @@ fun generateComplementaryPalette(
     count: Int
 ): MutableList<Palette.Color> {
     val rgbColors: MutableList<Array<Int>> = mutableListOf();
+
+    // get the opposite colour of each of the seeds
     for (color in seeds) {
         val rgb = color.rgb;
-        rgbColors.add(arrayOf(rgb.r, rgb.g, rgb.b))
+        // if the count is 1, we don't want to add the seed because it's already in the palette
+        // since the count is only 1 when we want to add a new colour
+        if (count > 1) {
+            rgbColors.add(arrayOf(rgb.r, rgb.g, rgb.b))
+        }
         val complementaryRgb = arrayOf(255 - rgb.r, 255 - rgb.g, 255 - rgb.b);
         rgbColors.add(complementaryRgb);
     }
@@ -194,7 +200,8 @@ fun generateAnalogicPalette(
     }
 
     var hslSeed = 0;
-    var currentCount = rgbColors.size;
+    // if the count is 1, then we still want to generate colours
+    var currentCount = if (count == 1) 0 else rgbColors.size;
     while (currentCount < count) {
         val hsl = rgbToHsl(rgbColors[hslSeed]);
         val newHueValues = getAnalogousHue(hsl[0], Random.nextDouble(0.05, 0.15));
@@ -208,7 +215,11 @@ fun generateAnalogicPalette(
 
     val result: MutableList<Palette.Color> = mutableListOf();
     for (color in 0..<count) {
-        val currColor = rgbColors[color];
+        var currColor = rgbColors[color];
+        // if the count is 1, then we want to get the first colour that is not the seed
+        if (count == 1) {
+            currColor = rgbColors[1];
+        }
         val rgb = Palette.Rgb(currColor[0], currColor[1], currColor[2]);
         val hexValue = rgbToHex(currColor);
         val hex = Palette.Hex("#$hexValue", hexValue);

--- a/app/src/main/java/com/example/palletify/ui/components/BottomSheet.kt
+++ b/app/src/main/java/com/example/palletify/ui/components/BottomSheet.kt
@@ -1,9 +1,12 @@
 package com.example.palletify.ui.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -15,6 +18,11 @@ fun BottomSheet(onDismiss: () -> Unit, content: @Composable() () -> Unit) {
         sheetState = modalBottomSheetState,
         dragHandle = null,
     ) {
-        content();
+        Column(
+            modifier = Modifier.navigationBarsPadding(),
+        ) {
+            content();
+        }
+        
     }
 }

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -91,7 +91,9 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                             )
                             activeColor = null
                         }
-                    ), text = "Add a new color to palette")
+                    ),
+                        color = if (generatorUiState.numberOfColours < 6) Color.Black else Color.LightGray,
+                        text = "Add a new color to palette")
                 }
                 HorizontalDivider()
                 Row(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
@@ -103,7 +105,9 @@ fun GeneratorScreen(generatorViewModel: GeneratorViewModel = viewModel()) {
                             )
                             activeColor = null
                         }
-                    ), text = "Remove this color from palette")
+                    ),
+                        color = if (generatorUiState.numberOfColours > 3) Color.Black else Color.LightGray,
+                        text = "Remove this color from palette")
                 }
             }
 

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -144,6 +144,16 @@ class GeneratorViewModel : ViewModel() {
         }
     }
 
+    private fun getColorMatchingPalette(mainColor: Palette.Color): Palette.Color {
+        val newColor = fetchPalette(
+            mutableSetOf(mainColor),
+            1,
+            currentPalette.mode
+        )[0];
+
+        return newColor;
+    }
+
     /*
     * Handle undo to go back to the previous palette
     */
@@ -185,29 +195,23 @@ class GeneratorViewModel : ViewModel() {
     * Handle increase number of colors shown in the palette
     */
     fun handleIncreaseNumOfColors(seed: Palette.Color) {
-        if (currentPalette.numberOfColours < MAX_NUMBER_OF_COLORS) {
-            currentPalette.numberOfColours++;
-            val newColors = listOf<Palette.Color>(
-                Palette.Color(
-                    Palette.Hex("#FFFFFF", "FFFFFF"),
-                    Palette.Rgb(
-                        255,
-                        255,
-                        255,
-                    ),
-                    Palette.Name("white")
-                )
-            );
-            val indexToAddNewColor = currentPalette.colors.indexOf(seed) + 1;
-            currentPalette.colors.add(indexToAddNewColor, newColors[0]);
-            val newPalette = currentPalette.colors.toMutableList();
-            _uiState.update { currentState ->
-                currentState.copy(
-                    numberOfColours = currentPalette.numberOfColours,
-                    currentPalette = newPalette
-                )
+        thread {
+            if (currentPalette.numberOfColours < MAX_NUMBER_OF_COLORS) {
+                val newCount = currentPalette.numberOfColours + 1;
+                currentPalette.numberOfColours = newCount;
+                val newColor = getColorMatchingPalette(seed);
+                val indexToAddNewColor = currentPalette.colors.indexOf(seed) + 1;
+                currentPalette.colors.add(indexToAddNewColor, newColor);
+                val newPalette = currentPalette.colors.toMutableList();
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        numberOfColours = newCount,
+                        currentPalette = newPalette
+                    )
+                }
             }
         }
+
     }
 
     /*
@@ -215,12 +219,13 @@ class GeneratorViewModel : ViewModel() {
     */
     fun handleDecreaseNumOfColors(color: Palette.Color) {
         if (currentPalette.numberOfColours > MIN_NUMBER_OF_COLORS) {
-            currentPalette.numberOfColours--;
+            val newCount = currentPalette.numberOfColours - 1;
+            currentPalette.numberOfColours = newCount
             currentPalette.colors.remove(color);
             val newPalette = currentPalette.colors.toMutableList();
             _uiState.update { currentState ->
                 currentState.copy(
-                    numberOfColours = currentPalette.numberOfColours,
+                    numberOfColours = newCount,
                     currentPalette = newPalette
                 )
             }

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -1,15 +1,9 @@
 package com.example.palletify.ui.generator
 
-import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
-import coil.ImageLoader
-import coil.request.ImageRequest
-import coil.request.SuccessResult
 import com.example.palletify.data.GenerationMode
 import com.example.palletify.data.Palette
 import com.example.palletify.data.TrademarkedColor
@@ -268,14 +262,14 @@ class GeneratorViewModel : ViewModel() {
             );
         }
     }
-    
+
     /*
     * Set colors in color palette based off an image
     */
-    fun setColorPaletteFromImage(colors: Map<String,String>) {
+    fun setColorPaletteFromImage(colors: Map<String, String>) {
         _colorPalette.value = colors
     }
-    
+
     /*
     * Update the generation mode
     */

--- a/timelog.md
+++ b/timelog.md
@@ -27,3 +27,4 @@
 | 03/27/2024 | 5    |          |       |             |        |      | Add menu to choose generation mode, add monochrome generation mode |
 | 03/28/2024 |      |          | 8     |             |        |      | Add gradient colour generator mode                                 |
 | 03/29/2024 |      |          | 8     |             |        |      | Create list of trademarked colours and warn user if used           |
+| 03/29/2024 |      |          | 3     |             |        |      | When adding new colours, generate it using our algorithms          |

--- a/timelog.md
+++ b/timelog.md
@@ -27,4 +27,4 @@
 | 03/27/2024 | 5    |          |       |             |        |      | Add menu to choose generation mode, add monochrome generation mode |
 | 03/28/2024 |      |          | 8     |             |        |      | Add gradient colour generator mode                                 |
 | 03/29/2024 |      |          | 8     |             |        |      | Create list of trademarked colours and warn user if used           |
-| 03/29/2024 |      |          | 3     |             |        |      | When adding new colours, generate it using our algorithms          |
+| 03/29/2024 |      |          | 5     |             |        |      | When adding new colours, generate it using our algorithms          |


### PR DESCRIPTION
Previously, when adding a new colour to the palette via the UI would add a hardcoded colour of white. This PR changes it so that we hook into our colour generation methods and generates the palette based on the mode that was used to generate the existing palette. 

https://github.com/emilyslouie/ece452-project/assets/52092223/ebcfddf4-4efa-46e8-95d3-e4e6fc382838

This PR also fixes the padding for the bottom sheet so that it doesn't overlap with the system navigation. It also greys out the buttons that are disabled if you cannot click them. 

While testing the change, there was an issue with all of the generation functions if the count passed in was 1. This is fixed now for everything but monochrome. 