### PR TITLE
Store color palette list as a object instead of string

### DIFF
--- a/app/src/main/java/com/example/palletify/ColorUtils.kt
+++ b/app/src/main/java/com/example/palletify/ColorUtils.kt
@@ -45,7 +45,7 @@ object ColorUtils {
         if (hex[0] == '#') {
             formattedHex = hex.substring(1);
         }
-        val bigint: Int = parseInt(formattedHex, 16)
+        val bigint: Int = formattedHex.toLong(16).toInt()
         val r: Int = bigint shr 16 and 255
         val g: Int = bigint shr 8 and 255
         val b: Int = bigint and 255
@@ -64,6 +64,11 @@ object ColorUtils {
         return componentToHex(rgb[0]).uppercase() + componentToHex(rgb[1]).uppercase() + componentToHex(
             rgb[2]
         ).uppercase();
+    }
+
+    fun Array<Int>.toRgb(): Palette.Rgb {
+        require(size == 3) { "Array must contain exactly three elements for Rgb conversion" }
+        return Palette.Rgb(get(0), get(1), get(2))
     }
 
 

--- a/app/src/main/java/com/example/palletify/ui/generator/GenerateWithImageScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GenerateWithImageScreen.kt
@@ -50,6 +50,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.style.TextAlign
+import com.example.palletify.ColorUtils.hexToRgb
+import com.example.palletify.ColorUtils.toRgb
+import com.example.palletify.data.GenerationMode
+import com.example.palletify.data.Palette
 import android.graphics.Color as GraphicsColor
 
 
@@ -64,8 +68,8 @@ fun GenerateWithImageScreen(
     val paletteViewModel =
         ViewModelProvider(context as ViewModelStoreOwner).get(PaletteViewModel::class.java)
 
-    val colors = remember { mutableStateListOf<String>()}
-    val moreColors = remember { mutableStateListOf<String>()}
+    val colors = remember { mutableStateListOf<Palette.Color>()}
+    val moreColors = remember { mutableStateListOf<Palette.Color>()}
 
     val colorPalette by generatorViewModel.colorPalette
 
@@ -89,22 +93,30 @@ fun GenerateWithImageScreen(
             if (bitmap != null) {
                 launchedEffectTriggered = true
                 generatorViewModel.setColorPaletteFromImage(
-                    colors = extractColorsFromBitmap(
+                    extractColorsFromBitmap(
                         bitmap = bitmap
                     )
                 )
                 var colorCount = 0
                 colorPalette.forEach { (_, value) ->
-                    if (!(colors.contains(value) || moreColors.contains(value))) {
-                        if (colorCount < 5) {
-                            colors.add(value)
+                    val colorObj = Palette.Color(
+                        Palette.Hex(value, value.substring(1)),
+                        hexToRgb(value).toRgb(),
+                        Palette.Name("")
+                    )
+                    if (!(colors.contains(colorObj) || moreColors.contains(colorObj))) {
+                        if (colorCount < MAX_NUMBER_OF_COLORS - 1) {
+                            colors.add(colorObj)
                             colorCount++
                         } else {
-                            moreColors.add(value)
+                            moreColors.add(colorObj)
                         }
                     }
-
                 }
+
+                var lockedColours = mutableSetOf<Palette.Color>()
+                var palette = GeneratorViewModel.PaletteObj(colorCount, colors, GenerationMode.ANY, lockedColours)
+                generatorViewModel.setCurrentPalette(palette)
             }
         } catch (e: Exception) {
             Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
@@ -140,11 +152,11 @@ fun GenerateWithImageScreen(
                         modifier = Modifier
                             .size(60.dp)
                             .clickable {
-                                onSelectionChange(color)
+                                onSelectionChange(color.hex.value)
                             }
-                            .background(Color(GraphicsColor.parseColor(color)))
+                            .background(Color(GraphicsColor.parseColor(color.hex.value)))
                             .border(
-                                if (color == selectedOption) {
+                                if (color.hex.value == selectedOption) {
                                     BorderStroke(1.5.dp, Color.DarkGray)
                                 } else {
                                     BorderStroke(0.dp, Color.White)
@@ -153,7 +165,7 @@ fun GenerateWithImageScreen(
                         ,
                     )
                 }
-                if (colors.size <= 5) {
+                if (colors.size < MAX_NUMBER_OF_COLORS) {
                     Button(
                         modifier = Modifier
                             .size(60.dp)
@@ -183,12 +195,11 @@ fun GenerateWithImageScreen(
                     .heightIn(min = 55.dp)
                     .fillMaxWidth(),
                     onClick = {
-                        val currentPalette = generatorViewModel.uiState.value.currentPalette
-                        val numberOfColors = generatorViewModel.uiState.value.numberOfColours
+                        val numberOfColors = colors.size
                         val mode = generatorViewModel.uiState.value.mode
                         val colorsList = mutableListOf<String>()
                         for (i in 0 until numberOfColors) {
-                            val color = currentPalette[i].hex.value
+                            val color = colors[i].hex.value
                             colorsList.add(color)
                         }
                         val palette = com.example.palletify.database.Palette(
@@ -228,8 +239,19 @@ fun GenerateWithImageScreen(
                         .padding(12.dp)
                         .heightIn(min = 55.dp).weight(1f),
                         onClick = {
-                            colors.remove(selectedOption)
-                            moreColors.add(selectedOption)
+                            if (colors.size > MIN_NUMBER_OF_COLORS) {
+                                val colorObj = Palette.Color(
+                                    Palette.Hex(selectedOption, selectedOption.substring(1)),
+                                    hexToRgb(selectedOption).toRgb(),
+                                    Palette.Name("")
+                                )
+
+                                colors.remove(colorObj)
+                                moreColors.add(colorObj)
+
+                            } else {
+                                Toast.makeText(context, "Need min of 3 colors", Toast.LENGTH_SHORT).show()
+                            }
                             onSelectionChange("")
                         }
                     ) {

--- a/app/src/main/java/com/example/palletify/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/home/HomeScreen.kt
@@ -169,15 +169,6 @@ fun HomeScreen(navigationController: NavController) {
             ) {
                 Text("Randomly generate colours")
             }
-//            Button(
-//                modifier = Modifier
-//                    .fillMaxWidth()
-//                    .padding(start = 28.dp, end = 28.dp)
-//                    .heightIn(min = 55.dp),
-//                onClick = { /* No action is triggered */ }
-//            ) {
-//                Text("Customize your own palette")
-//            }
         }
     }
 


### PR DESCRIPTION
Using `mutableStateListOf<Palette.Color>()` instead of `mutableStateListOf<String>()` for storing color values. This fixes the issue of palette generated not showing up correctly in the library.