### PR TITLE
Use color picker dialog for generator

### DIFF
--- a/app/src/main/java/com/example/palletify/ColorUtils.kt
+++ b/app/src/main/java/com/example/palletify/ColorUtils.kt
@@ -1,9 +1,8 @@
 package com.example.palletify
 
 import androidx.compose.ui.graphics.Color
-import androidx.core.graphics.toColorInt
 import com.example.palletify.data.Palette
-import java.lang.Integer.parseInt
+import com.example.palletify.data.fetchColorName
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
@@ -11,6 +10,30 @@ import kotlin.math.roundToInt
 import kotlin.random.Random
 
 object ColorUtils {
+    fun Color.toPaletteColorString(): String {
+        // Convert the floating-point values to 0-255 and then to a hex string
+        val redValue = (this.red * 255).toInt()
+        val greenValue = (this.green * 255).toInt()
+        val blueValue = (this.blue * 255).toInt()
+
+        return String.format("#%02X%02X%02X", redValue, greenValue, blueValue)
+    }
+
+    fun Color.toPaletteColor(): Palette.Color {
+        // Convert the floating-point values to 0-255 and then to a hex string
+        val redValue = (this.red * 255).toInt()
+        val greenValue = (this.green * 255).toInt()
+        val blueValue = (this.blue * 255).toInt()
+
+        val rgb = Palette.Rgb(redValue, greenValue, blueValue);
+        val hexValue =
+            String.format("#%02X%02X%02X", redValue, greenValue, blueValue)
+        val hex = Palette.Hex(hexValue, hexValue.substring(1));
+        val name = fetchColorName(hex);
+
+        return Palette.Color(hex, rgb, name);
+    }
+
     fun hexToComposeColor(hex: String): Color {
         return Color(android.graphics.Color.parseColor(hex));
     }

--- a/app/src/main/java/com/example/palletify/ui/components/ColorPickerDialog.kt
+++ b/app/src/main/java/com/example/palletify/ui/components/ColorPickerDialog.kt
@@ -105,7 +105,7 @@ fun ColorPickerDialog(
                             onDismissRequest()
                         }
                     ) {
-                        Text("Save")
+                        Text("OK")
                     }
                 }
             }

--- a/app/src/main/java/com/example/palletify/ui/components/ColorPickerDialog.kt
+++ b/app/src/main/java/com/example/palletify/ui/components/ColorPickerDialog.kt
@@ -1,0 +1,114 @@
+package com.example.palletify.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.github.skydoves.colorpicker.compose.AlphaTile
+import com.github.skydoves.colorpicker.compose.BrightnessSlider
+import com.github.skydoves.colorpicker.compose.ColorPickerController
+import com.github.skydoves.colorpicker.compose.HsvColorPicker
+
+@Composable
+fun ColorPickerDialog(
+    controller: ColorPickerController,
+    onDismissRequest: () -> Unit,
+    initialColor: Color,
+    onColorChanged: (Color) -> Unit,
+    onSave: (Color) -> Unit
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                HsvColorPicker(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 250.dp)
+                        .padding(10.dp),
+                    controller = controller,
+                    initialColor = initialColor
+                )
+                
+                BrightnessSlider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp)
+                        .height(35.dp),
+                    controller = controller,
+                    initialColor = initialColor
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier
+                        .padding(10.dp)
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(text = "Initial")
+                        AlphaTile(
+                            modifier = Modifier
+                                .size(80.dp),
+                            selectedColor = initialColor
+                        )
+                    }
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(text = "New")
+                        AlphaTile(
+                            modifier = Modifier
+                                .size(80.dp),
+                            controller = controller
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Button(
+                        onClick = onDismissRequest,
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text("Cancel")
+                    }
+                    Button(
+                        onClick = {
+                            val c = controller.selectedColor
+                            onSave(c.value)
+                            onDismissRequest()
+                        }
+                    ) {
+                        Text("Save")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -277,4 +277,20 @@ class GeneratorViewModel : ViewModel() {
             );
         }
     }
+
+    fun replaceColorInPalette(color: Palette.Color, colorToReplace: Palette.Color) {
+        val newPalette = currentPalette.colors;
+        val indexToReplace = newPalette.indexOf(colorToReplace);
+        if (indexToReplace == -1) return;
+        newPalette[indexToReplace] = color;
+        setCurrentPalette(
+            PaletteObj(
+                currentPalette.numberOfColours,
+                newPalette,
+                currentPalette.mode,
+                currentPalette.lockedColours
+            )
+        )
+
+    }
 }

--- a/app/src/main/java/com/example/palletify/ui/this_or_that/ThisOrThatScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/this_or_that/ThisOrThatScreen.kt
@@ -86,8 +86,10 @@ fun ThisOrThatScreen(thisOrThatViewModel: ThisOrThatViewModel = viewModel()) {
                         }
                         TextButton(
                             onClick = {
-                                val currentPalette = thisOrThatViewModel.uiState.value.currentPalettes[0].colors
-                                val numberOfColors = thisOrThatViewModel.uiState.value.currentPalettes[0].numberOfColours
+                                val currentPalette =
+                                    thisOrThatViewModel.uiState.value.currentPalettes[0].colors
+                                val numberOfColors =
+                                    thisOrThatViewModel.uiState.value.currentPalettes[0].numberOfColours
                                 val mode = thisOrThatViewModel.uiState.value.currentPalettes[0].mode
                                 val colorsList = mutableListOf<String>()
                                 for (i in 0 until numberOfColors) {
@@ -121,8 +123,10 @@ fun ThisOrThatScreen(thisOrThatViewModel: ThisOrThatViewModel = viewModel()) {
                         }
                         TextButton(
                             onClick = {
-                                val currentPalette = thisOrThatViewModel.uiState.value.currentPalettes[1].colors
-                                val numberOfColors = thisOrThatViewModel.uiState.value.currentPalettes[1].numberOfColours
+                                val currentPalette =
+                                    thisOrThatViewModel.uiState.value.currentPalettes[1].colors
+                                val numberOfColors =
+                                    thisOrThatViewModel.uiState.value.currentPalettes[1].numberOfColours
                                 val mode = thisOrThatViewModel.uiState.value.currentPalettes[1].mode
                                 val colorsList = mutableListOf<String>()
                                 for (i in 0 until numberOfColors) {
@@ -169,7 +173,11 @@ fun ThisOrThatScreen(thisOrThatViewModel: ThisOrThatViewModel = viewModel()) {
                 ) {
                     Row() {
                         if (thisOrThatUiState.currentPalettes.size > 0)
-                            Palettes(thisOrThatViewModel, thisOrThatUiState.currentPalettes, columnHeightDp)
+                            Palettes(
+                                thisOrThatViewModel,
+                                thisOrThatUiState.currentPalettes,
+                                columnHeightDp
+                            )
                     }
                 }
             }
@@ -186,9 +194,14 @@ fun Palettes(
 
     val numOfColors = currentPalettes[0].numberOfColours
     val heightPerColor = heightAvailable / numOfColors;
-    Column () {
+    Column() {
         for (i in 0..<numOfColors) {
-            ColorsInRow(thisOrThatViewModel, currentPalettes[0].colors[i], currentPalettes[1].colors[i], heightPerColor)
+            ColorsInRow(
+                thisOrThatViewModel,
+                currentPalettes[0].colors[i],
+                currentPalettes[1].colors[i],
+                heightPerColor
+            )
         }
     }
 }
@@ -233,7 +246,11 @@ fun ColorsInRow(
                     )
                     Text(
                         text = firstColor.name.value,
-                        color = if (luminosity >= 0.179) Color(35, 35, 35) else Color(230, 230, 230),
+                        color = if (luminosity >= 0.179) Color(35, 35, 35) else Color(
+                            230,
+                            230,
+                            230
+                        ),
                         style = typography.labelMedium
                     )
                 }
@@ -258,8 +275,6 @@ fun ColorsInRow(
                     calculateLuminosity(secondColor.rgb.r, secondColor.rgb.g, secondColor.rgb.b)
 
                 Column(
-                    modifier = Modifier
-                        .clickable { }
                 ) {
                     Text(
                         modifier = Modifier.padding(bottom = 2.dp),
@@ -269,7 +284,11 @@ fun ColorsInRow(
                     )
                     Text(
                         text = secondColor.name.value,
-                        color = if (luminosity >= 0.179) Color(35, 35, 35) else Color(230, 230, 230),
+                        color = if (luminosity >= 0.179) Color(35, 35, 35) else Color(
+                            230,
+                            230,
+                            230
+                        ),
                         style = typography.labelMedium
                     )
                 }

--- a/timelog.md
+++ b/timelog.md
@@ -38,3 +38,4 @@
 | 03/30/2024 |      |          | 4     |             |        |      | Begin scaffolding for This Or That generator                       |
 | 03/30/2024 |      |          |       |             | 5      |      | Finish This or That Generator + Bugfixes                           |
 | 03/30/2024 |      |          |       |             | 3      |      | Add Palette Building from Scratch for Preview + Polish Preview     |
+| 03/31/2024 |      |          | 5     |             |        |      | Add color picker for GeneratorScreen                               |


### PR DESCRIPTION
This PR moves the color picker dialog to its own file so that it can be reused for the generator. I added some quality of life things like seeing the old colour compared to the new colour, as well as removing the alpha slider since we don't really need that. 

It also moves some of the util to ColorUtils

[generator-color-picker.webm](https://github.com/emilyslouie/ece452-project/assets/52092223/efa0991d-030e-4ca6-9e0d-9b23b4c06ed7)


(Sorry about the reformatting of the file, just using the built-in formatter on save)