### PR TITLE
Add colour hexes on top of the colour palette when taking a picture

### DIFF
--- a/app/src/main/java/com/example/palletify/ui/generator/GenerateWithImageScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GenerateWithImageScreen.kt
@@ -142,7 +142,10 @@ fun GenerateWithImageScreen(
             ) {
                 colors.forEach { color ->
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(text = color.hex.clean.substring(3).uppercase())
+                        Text(
+                            text = if (color.hex.clean.length > 6) color.hex.clean.substring(2)
+                                .uppercase() else color.hex.clean
+                        )
                         Box(
                             modifier = Modifier
                                 .size(50.dp)

--- a/app/src/main/java/com/example/palletify/ui/generator/GenerateWithImageScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GenerateWithImageScreen.kt
@@ -29,11 +29,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModelProvider
@@ -41,19 +44,12 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberImagePainter
-import com.example.palletify.R
-import com.example.palletify.database.PaletteViewModel
-import java.lang.Long.parseLong
-import com.example.palletify.ui.generator.GenerateWithImage.convertImageUrlToBitmap
-import com.example.palletify.ui.generator.GenerateWithImage.extractColorsFromBitmap
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.style.TextAlign
 import com.example.palletify.ColorUtils.hexToRgb
 import com.example.palletify.ColorUtils.toRgb
-import com.example.palletify.data.GenerationMode
 import com.example.palletify.data.Palette
+import com.example.palletify.database.PaletteViewModel
+import com.example.palletify.ui.generator.GenerateWithImage.convertImageUrlToBitmap
+import com.example.palletify.ui.generator.GenerateWithImage.extractColorsFromBitmap
 import android.graphics.Color as GraphicsColor
 
 
@@ -68,8 +64,8 @@ fun GenerateWithImageScreen(
     val paletteViewModel =
         ViewModelProvider(context as ViewModelStoreOwner).get(PaletteViewModel::class.java)
 
-    val colors = remember { mutableStateListOf<Palette.Color>()}
-    val moreColors = remember { mutableStateListOf<Palette.Color>()}
+    val colors = remember { mutableStateListOf<Palette.Color>() }
+    val moreColors = remember { mutableStateListOf<Palette.Color>() }
 
     val colorPalette by generatorViewModel.colorPalette
 
@@ -133,7 +129,7 @@ fun GenerateWithImageScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Image(
                 painter = rememberImagePainter(uploadedImageUri),
@@ -141,31 +137,35 @@ fun GenerateWithImageScreen(
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.Bottom
             ) {
                 colors.forEach { color ->
-                    Box(
-                        modifier = Modifier
-                            .size(60.dp)
-                            .clickable {
-                                onSelectionChange(color.hex.value)
-                            }
-                            .background(Color(GraphicsColor.parseColor(color.hex.value)))
-                            .border(
-                                if (color.hex.value == selectedOption) {
-                                    BorderStroke(1.5.dp, Color.DarkGray)
-                                } else {
-                                    BorderStroke(0.dp, Color.White)
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(text = color.hex.clean.substring(3).uppercase())
+                        Box(
+                            modifier = Modifier
+                                .size(50.dp)
+                                .clickable {
+                                    onSelectionChange(color.hex.value)
                                 }
-                            )
-                        ,
-                    )
+                                .background(Color(GraphicsColor.parseColor(color.hex.value)))
+                                .border(
+                                    if (color.hex.value == selectedOption) {
+                                        BorderStroke(1.5.dp, Color.DarkGray)
+                                    } else {
+                                        BorderStroke(0.dp, Color.White)
+                                    }
+                                ),
+                        )
+                    }
+
                 }
                 if (colors.size < MAX_NUMBER_OF_COLORS) {
                     Button(
                         modifier = Modifier
-                            .size(60.dp)
-                            .heightIn(min = 55.dp),
+                            .size(50.dp)
+                            .heightIn(min = 45.dp),
 
                         onClick = {
                             if (moreColors.isNotEmpty()) {
@@ -177,7 +177,7 @@ fun GenerateWithImageScreen(
                         Text(
                             text = "+",
                             style = TextStyle(
-                                fontSize = 32.sp, fontWeight = FontWeight.Medium
+                                fontSize = 28.sp, fontWeight = FontWeight.Medium
                             ),
                             textAlign = TextAlign.Center
                         )
@@ -185,7 +185,7 @@ fun GenerateWithImageScreen(
                 }
 
             }
-            if (selectedOption == ""){
+            if (selectedOption == "") {
                 Button(modifier = Modifier
                     .padding(12.dp)
                     .heightIn(min = 55.dp)
@@ -217,10 +217,11 @@ fun GenerateWithImageScreen(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
-                ){
+                ) {
                     Button(modifier = Modifier
                         .padding(12.dp)
-                        .heightIn(min = 55.dp).weight(1f),
+                        .heightIn(min = 55.dp)
+                        .weight(1f),
                         onClick = {
                             onSelectionChange("")
                         }
@@ -233,7 +234,8 @@ fun GenerateWithImageScreen(
                     }
                     Button(modifier = Modifier
                         .padding(12.dp)
-                        .heightIn(min = 55.dp).weight(1f),
+                        .heightIn(min = 55.dp)
+                        .weight(1f),
                         onClick = {
                             if (colors.size > MIN_NUMBER_OF_COLORS) {
                                 val colorObj = Palette.Color(
@@ -246,7 +248,8 @@ fun GenerateWithImageScreen(
                                 moreColors.add(colorObj)
 
                             } else {
-                                Toast.makeText(context, "Need min of 3 colors", Toast.LENGTH_SHORT).show()
+                                Toast.makeText(context, "Need min of 3 colors", Toast.LENGTH_SHORT)
+                                    .show()
                             }
                             onSelectionChange("")
                         }

--- a/timelog.md
+++ b/timelog.md
@@ -43,3 +43,4 @@
 | 03/31/2024 |      |          | 5    |             |        |      | Add color picker for GeneratorScreen                               |
 | 03/31/2024 | 6    |          |      |             |        |      | Add triad and quad generation modes                                |
 | 03/31/2024 | 2.5  |          |      |             |        |      | Add AboutScreen and information to address Buddy Team feedback     |
+| 03/31/2024 |      |          | 0.5  |             |        |      | Add hexes in palette when taking picture                           |


### PR DESCRIPTION
![image](https://github.com/emilyslouie/ece452-project/assets/52092223/9232ed2b-7c0b-4313-a415-b73535e758a6)

This small change to address the fact that we need to adhere to our user scenarios in the proposal

> One user scenario is that a user is commuting home after work and notices a vibrant colour scheme on a storefront. They’re in the process of designing a personal website and think that this combination of colours could be the inspiration they need! They want to use the colours in their website but have no way of knowing the exact RGB or hex codes to use in their code. **Fortunately, they can use our app to take a photo of the storefront (functional property 2.1) and then tap to identify specific colours from the photo to add to a palette (functional property 2.2).**