### PR TITLE
Add ability to re-position colours in palette

### DIFF
--- a/app/src/main/java/com/example/palletify/data/Palette.kt
+++ b/app/src/main/java/com/example/palletify/data/Palette.kt
@@ -9,6 +9,7 @@ class Palette {
         val hex: Hex,
         val rgb: Rgb,
         val name: Name,
+        var index: Int = -1,
     ) {
         // Override default equals operator since it uses referential equality by default (compare addresses)
         // We want structural equality (compare values of all members in struct)

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +17,8 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Redo
 import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Refresh
@@ -275,7 +278,8 @@ fun Palette(
     onItemClick: (com.example.palletify.data.Palette.Color) -> Unit
 ) {
     val heightPerColor = heightAvailable / numOfColors;
-    colors.forEach { color ->
+    colors.forEachIndexed { index, color ->
+        color.index = index
         ColorInPalette(
             generatorViewModel,
             color,
@@ -324,7 +328,7 @@ fun ColorInPalette(
                 .height(heightPerColor)
                 .background(hexToComposeColor(color.hex.value.toString()))
                 .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
 
             ) {
@@ -345,27 +349,59 @@ fun ColorInPalette(
                 )
             }
 
-            if (!generatorUiState.lockedColors.contains(color)) {
-                // Button to lock a colour
-                IconButton(
-                    onClick = { generatorViewModel.handleLockForColor(color) }
-                ) {
-                    Icon(
-                        Icons.Filled.LockOpen,
-                        contentDescription = "Lock a colour",
-                        tint = if (luminosity >= 0.179) Color.Black else Color.White
-                    )
+            Spacer(modifier = Modifier.weight(1.0f))
+
+            Column(
+            ) {
+                if (color.index != 0) {
+                    // Button to move a colour up
+                    IconButton(
+                        onClick = { generatorViewModel.handleMoveColourUp(color) }
+                    ) {
+                        Icon(
+                            Icons.Filled.ArrowUpward,
+                            contentDescription = "Move a colour up",
+                            tint = if (luminosity >= 0.179) Color.Black else Color.White
+                        )
+                    }
                 }
-            } else {
-                // Button to unlock a colour
-                IconButton(
-                    onClick = { generatorViewModel.handleUnlockForColor(color) }
-                ) {
-                    Icon(
-                        Icons.Filled.Lock,
-                        contentDescription = "Unlock a colour",
-                        tint = if (luminosity >= 0.179) Color.Black else Color.White
-                    )
+                if (color.index != generatorUiState.numberOfColours - 1) {
+                    // Button to move a colour down
+                    IconButton(
+                        onClick = { generatorViewModel.handleMoveColourDown(color) }
+                    ) {
+                        Icon(
+                            Icons.Filled.ArrowDownward,
+                            contentDescription = "Move a colour down",
+                            tint = if (luminosity >= 0.179) Color.Black else Color.White
+                        )
+                    }
+                }
+            }
+
+            Row() {
+                if (!generatorUiState.lockedColors.contains(color)) {
+                    // Button to lock a colour
+                    IconButton(
+                        onClick = { generatorViewModel.handleLockForColor(color) }
+                    ) {
+                        Icon(
+                            Icons.Filled.LockOpen,
+                            contentDescription = "Lock a colour",
+                            tint = if (luminosity >= 0.179) Color.Black else Color.White
+                        )
+                    }
+                } else {
+                    // Button to unlock a colour
+                    IconButton(
+                        onClick = { generatorViewModel.handleUnlockForColor(color) }
+                    ) {
+                        Icon(
+                            Icons.Filled.Lock,
+                            contentDescription = "Unlock a colour",
+                            tint = if (luminosity >= 0.179) Color.Black else Color.White
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/example/palletify/ui/generator/GeneratorViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import java.util.Collections
 import kotlin.concurrent.thread
 
 
@@ -291,6 +292,39 @@ class GeneratorViewModel : ViewModel() {
                 currentPalette.lockedColours
             )
         )
+    }
 
+    /*
+    * Move a colour "up" in the Palette's color list
+    */
+    fun handleMoveColourUp(color: Palette.Color) {
+        val reorderedColours = currentPalette.colors;
+        // swap with colour in list above it
+        Collections.swap(reorderedColours, color.index, color.index - 1)
+        setCurrentPalette(
+            PaletteObj(
+                currentPalette.numberOfColours,
+                reorderedColours,
+                currentPalette.mode,
+                currentPalette.lockedColours
+            )
+        )
+    }
+
+    /*
+    * Move a colour "down" in the Palette's color list
+    */
+    fun handleMoveColourDown(color: Palette.Color) {
+        val reorderedColours = currentPalette.colors;
+        // swap with colour in list above it
+        Collections.swap(reorderedColours, color.index, color.index + 1)
+        setCurrentPalette(
+            PaletteObj(
+                currentPalette.numberOfColours,
+                reorderedColours,
+                currentPalette.mode,
+                currentPalette.lockedColours
+            )
+        )
     }
 }

--- a/timelog.md
+++ b/timelog.md
@@ -1,46 +1,47 @@
 | Date       | Matt | Victoria | Emily | Padmaashini | Lokhin | Zihe | Task                                                               |
-|------------|------|----------|------|-------------|--------|------|--------------------------------------------------------------------|
-| 02/17/2024 |      |          | 0.5  |             |        |      | Set up initial project                                             |
-| 02/21/2024 |      |          | 2    |             |        |      | Added template functions for generator                             |
-| 02/21/2024 |      |          | 3    |             |        |      | Get random colour and palette from API                             |
-| 02/22/2024 |      |          | 3.5  |             |        |      | Display and generate colour palette on click                       |
-| 02/23/2024 |      |          | 3    |             |        |      | Fix generator UI and text contrast                                 |
-| 02/25/2024 |      | 3        |      |             |        |      | Implementing the menu and navigation bar                           |
-| 02/25/2024 |      |          |      |             |        | 3    | Adding functioning photo capturing feature                         |
-| 02/26/2024 |      |          | 6    |             |        |      | Implement undo/redo for generating palettes                        |
-| 02/27/2024 |      |          |      | 6.5         |        |      | Add Preview screen and various UI elements in it                   |
-| 02/28/2024 |      |          |      |             | 3      |      | Add colour selection for preview                                   |
-| 02/28/2024 | 6    |          |      |             |        |      | Implement UI and API calls to lock/unlock colours                  |
-| 02/28/2024 | 0.5  |          |      |             |        |      | Persist locked colours across undo/redo state changes              |
-| 02/28/2024 |      |          |      |             |        | 4    | Refactoring photo capturing to better fit software architecture    |
-| 03/01/2024 |      | 6        |      |             |        |      | Saving colours locally to database, screen updates                 |
-| 03/02/2024 |      |          |      |             |        | 2    | Adding image importing functionality                               |
-| 03/02/2024 |      |          |      |             | 1      |      | Refactor Model into separate files and fix conflicts               |
-| 03/02/2024 |      |          |      | 4           |        |      | Accessibility checker                                              |
-| 03/03/2024 |      |          |      |             |        | 1    | Add sample image color template                                    |
-| 03/12/2024 |      |          | 6    |             |        |      | Increase or decrease number of colours in palette                  |
-| 03/24/2024 |      |          | 6    |             |        |      | Implement plumbing to handle our own colour generation methods     |
-| 03/24/2024 |      |          | 4    |             |        |      | Add complementary colour generation mode                           |
-| 03/25/2024 |      |          | 3    |             |        |      | Add analogous colour generation mode                               |
-| 03/26/2024 |      |          | 2    |             |        |      | Add random colour generator mode                                   |
-| 03/26/2024 |      |          |      |             |        |  6   | Get colorAPI working with images                                   |
-| 03/27/2024 |      |          | 2    |             |        |      | Fetch colour name and display it in generator                      |
-| 03/27/2024 | 5    |          |      |             |        |      | Add menu to choose generation mode, add monochrome generation mode |
-| 03/27/2024 |      |          |      |             |        |  4   | Update UI for image page to be more user friendly and interactive  |
-| 03/28/2024 |      |          |      |             |        |  6   | Get image generate palette working with library page               |
-| 03/28/2024 |      |          | 8    |             |        |      | Add gradient colour generator mode                                 |
-| 03/28/2024 |      |          |      |             | 4      |      | Load Palette Colours in Preview Page - Components                  |
-| 03/28/2024 |      |          |      | 5.5         |        |      | Edit Palette Colours in Preview Page - Components                  |
-| 03/29/2024 |      |          | 8    |             |        |      | Create list of trademarked colours and warn user if used           |
-| 03/29/2024 |      |          | 5    |             |        |      | When adding new colours, generate it using our algorithms          |
-| 03/29/2024 |      |          |      | 7           |        |      | Persist Color Edits in Database + Add Constrast Modal              |
-| 03/29/2024 |      |          |      |             |        |  5   | Refactoring app navigation                                         |
-| 03/30/2024 |      |          | 4    |             |        |      | Begin scaffolding for This Or That generator                       |
-| 03/30/2024 |      |          |      |             | 5      |      | Finish This or That Generator + Bugfixes                           |
-| 03/30/2024 |      |          |      |             | 3      |      | Add Palette Building from Scratch for Preview + Polish Preview     |
-| 03/30/2024 |      |          |      | 6           |        |      | Research Into and Experiment with Color Blindness Filter Options   |
-| 03/30/2024 |      |          |      | 2           |        |      | Impelement Color Blindness Filters Using Color Matrix Operations   |
-| 03/31/2024 |      |          | 5    |             |        |      | Add color picker for GeneratorScreen                               |
-| 03/31/2024 | 6    |          |      |             |        |      | Add triad and quad generation modes                                |
-| 03/31/2024 | 2.5  |          |      |             |        |      | Add AboutScreen and information to address Buddy Team feedback     |
-| 03/31/2024 |      |          | 0.5  |             |        |      | Add hexes in palette when taking picture                           |
+|------------|------|----------|-------|-------------|--------|------|--------------------------------------------------------------------|
+| 02/17/2024 |      |          | 0.5   |             |        |      | Set up initial project                                             |
+| 02/21/2024 |      |          | 2     |             |        |      | Added template functions for generator                             |
+| 02/21/2024 |      |          | 3     |             |        |      | Get random colour and palette from API                             |
+| 02/22/2024 |      |          | 3.5   |             |        |      | Display and generate colour palette on click                       |
+| 02/23/2024 |      |          | 3     |             |        |      | Fix generator UI and text contrast                                 |
+| 02/25/2024 |      | 3        |       |             |        |      | Implementing the menu and navigation bar                           |
+| 02/25/2024 |      |          |       |             |        | 3    | Adding functioning photo capturing feature                         |
+| 02/26/2024 |      |          | 6     |             |        |      | Implement undo/redo for generating palettes                        |
+| 02/27/2024 |      |          |       | 6.5         |        |      | Add Preview screen and various UI elements in it                   |
+| 02/28/2024 |      |          |       |             | 3      |      | Add colour selection for preview                                   |
+| 02/28/2024 | 6    |          |       |             |        |      | Implement UI and API calls to lock/unlock colours                  |
+| 02/28/2024 | 0.5  |          |       |             |        |      | Persist locked colours across undo/redo state changes              |
+| 02/28/2024 |      |          |       |             |        | 4    | Refactoring photo capturing to better fit software architecture    |
+| 03/01/2024 |      | 6        |       |             |        |      | Saving colours locally to database, screen updates                 |
+| 03/02/2024 |      |          |       |             |        | 2    | Adding image importing functionality                               |
+| 03/02/2024 |      |          |       |             | 1      |      | Refactor Model into separate files and fix conflicts               |
+| 03/02/2024 |      |          |       | 4           |        |      | Accessibility checker                                              |
+| 03/03/2024 |      |          |       |             |        | 1    | Add sample image color template                                    |
+| 03/12/2024 |      |          | 6     |             |        |      | Increase or decrease number of colours in palette                  |
+| 03/24/2024 |      |          | 6     |             |        |      | Implement plumbing to handle our own colour generation methods     |
+| 03/24/2024 |      |          | 4     |             |        |      | Add complementary colour generation mode                           |
+| 03/25/2024 |      |          | 3     |             |        |      | Add analogous colour generation mode                               |
+| 03/26/2024 |      |          | 2     |             |        |      | Add random colour generator mode                                   |
+| 03/26/2024 |      |          |       |             |        | 6    | Get colorAPI working with images                                   |
+| 03/27/2024 |      |          | 2     |             |        |      | Fetch colour name and display it in generator                      |
+| 03/27/2024 | 5    |          |       |             |        |      | Add menu to choose generation mode, add monochrome generation mode |
+| 03/27/2024 |      |          |       |             |        | 4    | Update UI for image page to be more user friendly and interactive  |
+| 03/28/2024 |      |          |       |             |        | 6    | Get image generate palette working with library page               |
+| 03/28/2024 |      |          | 8     |             |        |      | Add gradient colour generator mode                                 |
+| 03/28/2024 |      |          |       |             | 4      |      | Load Palette Colours in Preview Page - Components                  |
+| 03/28/2024 |      |          |       | 5.5         |        |      | Edit Palette Colours in Preview Page - Components                  |
+| 03/29/2024 |      |          | 8     |             |        |      | Create list of trademarked colours and warn user if used           |
+| 03/29/2024 |      |          | 5     |             |        |      | When adding new colours, generate it using our algorithms          |
+| 03/29/2024 |      |          |       | 7           |        |      | Persist Color Edits in Database + Add Constrast Modal              |
+| 03/29/2024 |      |          |       |             |        | 5    | Refactoring app navigation                                         |
+| 03/30/2024 |      |          | 4     |             |        |      | Begin scaffolding for This Or That generator                       |
+| 03/30/2024 |      |          |       |             | 5      |      | Finish This or That Generator + Bugfixes                           |
+| 03/30/2024 |      |          |       |             | 3      |      | Add Palette Building from Scratch for Preview + Polish Preview     |
+| 03/30/2024 |      |          |       | 6           |        |      | Research Into and Experiment with Color Blindness Filter Options   |
+| 03/30/2024 |      |          |       | 2           |        |      | Impelement Color Blindness Filters Using Color Matrix Operations   |
+| 03/31/2024 |      |          | 5     |             |        |      | Add color picker for GeneratorScreen                               |
+| 03/31/2024 | 6    |          |       |             |        |      | Add triad and quad generation modes                                |
+| 03/31/2024 | 2.5  |          |       |             |        |      | Add AboutScreen and information to address Buddy Team feedback     |
+| 03/31/2024 |      |          | 0.5   |             |        |      | Add hexes in palette when taking picture                           |
+| 03/31/2024 | 2    |          |       |             |        |      | Add ability to reorder position of colours in palette              |


### PR DESCRIPTION
- Added index property to Color object so that colors know their relative position in the palette list
- Added buttons to re-position colours up or down in the palette
- Set index of new colours when single colours are added using the bottom sheet

[Reordering Demo.webm](https://github.com/emilyslouie/ece452-project/assets/78515835/8df7bf72-0163-4ddc-8008-b5b5610f14f3)
